### PR TITLE
( from 0 to 1) TeleOpV4 default slide state conversion

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/CCTeleOpControllerV4.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/CCTeleOpControllerV4.java
@@ -174,7 +174,7 @@ public class CCTeleOpControllerV4 extends OpMode {
         if(downGrabTimer == 0)
         {
             pixelPlacerState = 0;
-            slideState = 0;
+            slideState = 1;
         }
     }
 
@@ -331,7 +331,7 @@ public class CCTeleOpControllerV4 extends OpMode {
     {
         if(!fingers) {
             pixelPlacerState = 0;
-            slideState = 0;
+            slideState = 1;
         }
     }
 


### PR DESCRIPTION
the default state when placing pixels should probably be 1 not 0. It may be 2 in the future.

Before issuing a pull request, please see the contributing page.
